### PR TITLE
[codex] harden a2a foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,15 +50,25 @@ Ports upstream `siteboon/claudecodeui` v1.30.0 features on top of Pixcode's v1.2
 * new UI primitives (Alert, Card, Collapsible, Command, Confirmation, Dialog, Reasoning, Shimmer, PromptInput, Queue) usable from `@/shared/view/ui`
 * add `PlanDisplay` and `ToolStatusBadge` helpers for the upcoming chat redesign
 * add history view switch (Recent / By project), session action menu, session starring, and time-bucketed flat list in the sidebar
+* **orchestration:** add A2A adapters for Codex, Cursor, Gemini, Qwen, and OpenCode so all first-party CLI integrations are reachable from `/a2a/*`
+* **orchestration:** add `POST /a2a/adapters/resolve` and `GET /a2a/tasks` for adapter dry-run resolution plus task listing/filtering
+* **orchestration:** persist A2A tasks to disk with restart recovery and task summary responses for external clients
 
 ### Refactoring
 
 * provider runtimes consolidated under `server/modules/providers/*` with auth/sessions/MCP split into dedicated providers (upstream PR [#666](https://github.com/siteboon/claudecodeui/pull/666))
 * chat composer, tool display, plan mode, and session model selector rebuilt on top of the new primitives (upstream refactor commits [7763e60](https://github.com/siteboon/claudecodeui/commit/7763e60), [5758bee](https://github.com/siteboon/claudecodeui/commit/5758bee), [ec0ff97](https://github.com/siteboon/claudecodeui/commit/ec0ff97))
+* **orchestration:** split task persistence into a dedicated A2A task store and extend the orchestration barrel/types surface for summaries and multi-adapter boot registration
 
 ### Bug Fixes
 
 * iOS scrolling in main chat area, mobile permission mode button tap target and provider selector sizing, PlanDisplay raw params migration, precise Claude SDK denial detection
+* **orchestration:** keep the A2A layer opt-in while hardening selector resolution, task-scoped message history, missing-task errors, and richer adapter-not-found responses
+* **orchestration:** make smoke/API coverage reflect the real six-adapter boot set and validate resolve/listing negative paths
+
+### Tests
+
+* **orchestration:** extend `scripts/smoke/a2a-roundtrip.mjs` to cover adapter registration, resolution, invalid submit/message paths, task listing, and the task stream happy path
 
 ## [1.29.5](https://github.com/alicomert/pixcode/compare/v1.29.4...v1.29.5) (2026-04-16)
 

--- a/docs/superpowers/plans/2026-04-28-orchestration-a2a-foundation.md
+++ b/docs/superpowers/plans/2026-04-28-orchestration-a2a-foundation.md
@@ -12,6 +12,18 @@
 
 **Out of scope for this plan:** five remaining adapters (Codex, Cursor, Gemini, Qwen, OpenCode), worktree/Docker isolation, port watcher, task board UI, workflow DAG runner. Each gets its own plan after this one ships.
 
+## Progress Update
+
+- [x] Foundation module shipped: `server/modules/orchestration/` with `types`, `bus`, `auth.middleware`, `agent-card`, `validator`, `adapter-registry`, `routes`
+- [x] Claude Code A2A adapter shipped and mounted under `/a2a/*`
+- [x] Remaining first-party adapters landed after the initial foundation: `codex`, `cursor`, `gemini`, `qwen`, `opencode`
+- [x] Durable A2A task persistence added via `task-store.ts` with restart recovery and terminal-task TTL eviction
+- [x] External-client ergonomics added: `POST /a2a/adapters/resolve`, `GET /a2a/tasks`, task summaries, selector/routing hints
+- [x] Smoke coverage expanded beyond the original Claude-only roundtrip to cover full adapter registration plus API negative paths
+- [ ] Still pending beyond foundation scope: workflow DAG runner, task board orchestration UI, worktree/Docker execution isolation, port watcher/auto-preview
+
+**Status:** The original foundation goal is complete and has been extended into a six-adapter, opt-in A2A surface. The remaining work is now productization and orchestration depth, not basic protocol bootstrapping.
+
 ---
 
 ## Verification approach (CLAUDE.md-compliant)

--- a/scripts/smoke/a2a-roundtrip.mjs
+++ b/scripts/smoke/a2a-roundtrip.mjs
@@ -25,6 +25,15 @@ async function jget(path) {
   return r.json();
 }
 
+async function jpost(path, body) {
+  const r = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: r.status, json: await r.json() };
+}
+
 async function main() {
   console.log('1) /a2a/.well-known/agent-card.json');
   const card = await jget('/a2a/.well-known/agent-card.json');
@@ -35,28 +44,88 @@ async function main() {
   const agents = await jget('/a2a/agents');
   const ids = agents.agents.map((a) => a.name);
   console.log('   registered:', ids.join(', '));
-  if (!ids.includes('pixcode-claude-code')) {
-    throw new Error('claude-code adapter not registered');
+  const expectedAgents = [
+    'pixcode-claude-code',
+    'pixcode-codex',
+    'pixcode-cursor',
+    'pixcode-gemini',
+    'pixcode-qwen',
+    'pixcode-opencode',
+  ];
+  for (const expected of expectedAgents) {
+    if (!ids.includes(expected)) {
+      throw new Error(`${expected} adapter not registered`);
+    }
   }
 
-  console.log('3) POST /a2a/tasks');
-  const submitRes = await fetch(`${baseUrl}/a2a/tasks`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      adapterId: 'claude-code',
-      message: {
-        messageId: 'm_smoke_1',
-        role: 'user',
-        parts: [{ kind: 'text', text: 'Reply with the single word: ok' }],
-      },
-    }),
+  console.log('3) POST /a2a/adapters/resolve');
+  const resolveRes = await jpost('/a2a/adapters/resolve', {
+    adapterId: 'skill:typescript-edit',
+    routing: { preferredAdapterId: 'codex' },
   });
-  if (!submitRes.ok) throw new Error(`submit -> ${submitRes.status}`);
-  const task = await submitRes.json();
-  console.log('   task.id=', task.id, 'state=', task.state);
+  if (resolveRes.status !== 200) throw new Error(`resolve -> ${resolveRes.status}`);
+  console.log('   resolved=', resolveRes.json.resolvedAdapterId);
+  if (resolveRes.json.resolvedAdapterId !== 'codex') {
+    throw new Error('skill resolution did not honor preferredAdapterId=codex');
+  }
 
-  console.log('4) GET /a2a/tasks/:id/stream (SSE)');
+  console.log('4) POST /a2a/tasks (invalid adapter)');
+  const invalidSubmit = await jpost('/a2a/tasks', {
+    adapterId: 'missing-adapter',
+    message: {
+      messageId: 'm_invalid_adapter',
+      role: 'user',
+      parts: [{ kind: 'text', text: 'noop' }],
+    },
+  });
+  if (invalidSubmit.status !== 404) {
+    throw new Error(`invalid submit -> expected 404, got ${invalidSubmit.status}`);
+  }
+
+  console.log('5) POST /a2a/messages (missing task)');
+  const missingTaskMessage = await jpost('/a2a/messages', {
+    messageId: 'm_missing_task',
+    role: 'user',
+    taskId: 'task_missing',
+    parts: [{ kind: 'text', text: 'noop' }],
+  });
+  if (missingTaskMessage.status !== 404) {
+    throw new Error(`missing task message -> expected 404, got ${missingTaskMessage.status}`);
+  }
+
+  console.log('6) POST /a2a/tasks');
+  const submitRes = await jpost('/a2a/tasks', {
+    adapterId: 'claude-code',
+    message: {
+      messageId: 'm_smoke_1',
+      role: 'user',
+      parts: [{ kind: 'text', text: 'Reply with the single word: ok' }],
+    },
+  });
+  if (submitRes.status !== 202) throw new Error(`submit -> ${submitRes.status}`);
+  const task = submitRes.json;
+  console.log('   task.id=', task.id, 'state=', task.state);
+  if (task.history?.[0]?.taskId !== task.id) {
+    throw new Error('task-scoped initial history message is missing taskId');
+  }
+  if (task.metadata?.adapterId !== 'claude-code') {
+    throw new Error('resolved adapterId was not persisted to task metadata');
+  }
+
+  console.log('7) GET /a2a/tasks?adapterId=claude-code&limit=5');
+  const listedTasks = await jget('/a2a/tasks?adapterId=claude-code&limit=5');
+  if (!Array.isArray(listedTasks.tasks) || listedTasks.count < 1) {
+    throw new Error('task listing did not return any tasks');
+  }
+  const listedTask = listedTasks.tasks.find((entry) => entry.id === task.id);
+  if (!listedTask) {
+    throw new Error('submitted task did not appear in filtered task listing');
+  }
+  if (listedTask.adapterId !== 'claude-code') {
+    throw new Error('task summary adapterId mismatch');
+  }
+
+  console.log('8) GET /a2a/tasks/:id/stream (SSE)');
   const streamRes = await fetch(`${baseUrl}/a2a/tasks/${task.id}/stream`);
   if (!streamRes.ok) throw new Error(`stream -> ${streamRes.status}`);
 

--- a/server/index.js
+++ b/server/index.js
@@ -75,6 +75,11 @@ import {
   createA2ARouter,
   adapterRegistry,
   ClaudeCodeA2AAdapter,
+  CodexA2AAdapter,
+  CursorA2AAdapter,
+  GeminiA2AAdapter,
+  OpenCodeA2AAdapter,
+  QwenA2AAdapter,
 } from './modules/orchestration/index.js';
 import networkRoutes from './routes/network.js';
 import telegramRoutes from './routes/telegram.js';
@@ -383,6 +388,11 @@ app.use('/api/providers', authenticateToken, providerRoutes);
 
 // A2A protocol router — has its own auth middleware, do NOT wrap with authenticateToken
 adapterRegistry.register(new ClaudeCodeA2AAdapter());
+adapterRegistry.register(new CodexA2AAdapter());
+adapterRegistry.register(new CursorA2AAdapter());
+adapterRegistry.register(new GeminiA2AAdapter());
+adapterRegistry.register(new QwenA2AAdapter());
+adapterRegistry.register(new OpenCodeA2AAdapter());
 app.use('/a2a', createA2ARouter());
 
 // Network discovery / QR endpoints (protected)

--- a/server/modules/orchestration/a2a/adapter-registry.ts
+++ b/server/modules/orchestration/a2a/adapter-registry.ts
@@ -4,11 +4,17 @@
 //   - "claude-code"        explicit
 //   - "skill:<skillId>"    first REGISTERED adapter advertising that skill
 //                          (Map iteration is insertion-ordered per ES spec).
-//   - "auto"               first registered adapter (placeholder until
-//                          AI-suggested routing arrives in a later plan)
+//   - "auto"               first registered adapter (deterministic fallback
+//                          until smarter routing arrives in a later plan)
 
 import type { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
 import type { AgentCard } from '@/modules/orchestration/a2a/types.js';
+
+interface ResolveAdapterOptions {
+  preferredAdapterId?: string;
+  preferredProvider?: string;
+  preferredSkillId?: string;
+}
 
 class AdapterRegistry {
   // Map iteration order is insertion-ordered (ES spec); auto and skill: resolution depend on this.
@@ -21,28 +27,35 @@ class AdapterRegistry {
     this.byId.set(adapter.id, adapter);
   }
 
-  get(idOrSelector: string): AbstractA2AAdapter | undefined {
-    if (idOrSelector === 'auto') {
-      if (this.byId.size > 1) {
-        throw new Error(
-          'A2A adapter selector "auto" is not yet implemented for multi-adapter registries. ' +
-          'Pass an explicit adapter id ("claude-code") or a "skill:<id>" selector. ' +
-          'AI-suggested routing will replace this stub in a later plan.',
-        );
-      }
-      const first = this.byId.values().next().value;
-      return first ?? undefined;
-    }
-    if (idOrSelector.startsWith('skill:')) {
-      const skill = idOrSelector.slice('skill:'.length);
-      for (const adapter of this.byId.values()) {
-        if (adapter.agentCard.skills.some((s) => s.id === skill)) {
-          return adapter;
-        }
-      }
+  get(id: string): AbstractA2AAdapter | undefined {
+    return this.byId.get(id);
+  }
+
+  resolve(idOrSelector: string, options: ResolveAdapterOptions = {}): AbstractA2AAdapter | undefined {
+    const normalizedSelector = idOrSelector.trim();
+    if (!normalizedSelector) {
       return undefined;
     }
-    return this.byId.get(idOrSelector);
+
+    if (normalizedSelector === 'auto') {
+      return this.pickPreferred(this.list(), options);
+    }
+
+    if (normalizedSelector.startsWith('skill:')) {
+      const skill = normalizedSelector.slice('skill:'.length);
+      const matches = this.list().filter((adapter) =>
+        adapter.agentCard.skills.some((s) => s.id === skill),
+      );
+      if (matches.length === 0) {
+        return undefined;
+      }
+      return this.pickPreferred(matches, {
+        ...options,
+        preferredSkillId: options.preferredSkillId ?? skill,
+      });
+    }
+
+    return this.byId.get(normalizedSelector);
   }
 
   list(): AbstractA2AAdapter[] {
@@ -52,7 +65,44 @@ class AdapterRegistry {
   agentCards(): AgentCard[] {
     return this.list().map((a) => a.agentCard);
   }
+
+  private pickPreferred(
+    adapters: AbstractA2AAdapter[],
+    options: ResolveAdapterOptions,
+  ): AbstractA2AAdapter | undefined {
+    const {
+      preferredAdapterId,
+      preferredProvider,
+      preferredSkillId,
+    } = options;
+
+    if (preferredAdapterId) {
+      const byAdapterId = adapters.find((adapter) => adapter.id === preferredAdapterId);
+      if (byAdapterId) {
+        return byAdapterId;
+      }
+    }
+
+    if (preferredProvider) {
+      const normalizedProvider = preferredProvider.trim().toLowerCase();
+      const byProvider = adapters.find((adapter) => adapter.id === normalizedProvider);
+      if (byProvider) {
+        return byProvider;
+      }
+    }
+
+    if (preferredSkillId) {
+      const bySkill = adapters.find((adapter) =>
+        adapter.agentCard.skills.some((skill) => skill.id === preferredSkillId),
+      );
+      if (bySkill) {
+        return bySkill;
+      }
+    }
+
+    return adapters[0];
+  }
 }
 
 export const adapterRegistry = new AdapterRegistry();
-export type { AdapterRegistry };
+export type { AdapterRegistry, ResolveAdapterOptions };

--- a/server/modules/orchestration/a2a/adapters/codex.adapter.ts
+++ b/server/modules/orchestration/a2a/adapters/codex.adapter.ts
@@ -1,0 +1,243 @@
+// server/modules/orchestration/a2a/adapters/codex.adapter.ts
+// Wraps the existing server/openai-codex.js queryCodex() runtime.
+// That runtime already emits provider-neutral NormalizedMessage frames,
+// so this adapter mainly translates those frames into A2A bus events.
+
+import crypto from 'node:crypto';
+
+// eslint-disable-next-line boundaries/no-unknown -- openai-codex.js is a top-level CLI runtime not yet classified by eslint.config.js; cleanup deferred.
+import { abortCodexSession, queryCodex } from '@/openai-codex.js';
+import { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type {
+  AdapterContext,
+  TaskHandle,
+} from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type { AgentCard, Part, Task } from '@/modules/orchestration/a2a/types.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+interface FakeWriter {
+  send(data: unknown): void;
+  isSSEStreamWriter: true;
+}
+
+function joinPartsToPrompt(parts: Part[]): string {
+  return parts
+    .map((part) => {
+      if (part.kind === 'text') return part.text;
+      if (part.kind === 'data') return JSON.stringify(part.data);
+      return `[file:${part.name}${part.uri ? ` uri=${part.uri}` : ''}]`;
+    })
+    .join('\n');
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export class CodexA2AAdapter extends AbstractA2AAdapter {
+  readonly id = 'codex';
+
+  readonly agentCard: AgentCard = {
+    name: 'pixcode-codex',
+    description: 'OpenAI Codex, accessed via Pixcode',
+    url: '/a2a/agents/codex',
+    version: '1.0.0',
+    capabilities: ['streaming', 'fileEdit', 'commandExec', 'webSearch', 'mcp'],
+    skills: [
+      {
+        id: 'typescript-edit',
+        description: 'Edit TypeScript and JavaScript files with CLI-driven reasoning',
+      },
+      {
+        id: 'command-execution',
+        description: 'Run shell commands and react to their output',
+      },
+      {
+        id: 'web-research',
+        description: 'Use web search as part of the development workflow',
+      },
+      {
+        id: 'task-planning',
+        description: 'Create and update TODO-style execution plans',
+      },
+    ],
+    authentication: { type: 'bearer' },
+  };
+
+  private readonly active = new Map<string, { sessionId: string | null }>();
+
+  async submitTask(task: Task, ctx: AdapterContext): Promise<TaskHandle> {
+    const promptText = joinPartsToPrompt(
+      task.history[task.history.length - 1]?.parts ?? [],
+    );
+    const session = { sessionId: null as string | null };
+    this.active.set(task.id, session);
+
+    this.emitState(task.id, 'working');
+
+    const fakeWriter: FakeWriter = {
+      isSSEStreamWriter: true,
+      send: (data) => this.handleRuntimeFrame(task.id, data, session),
+    };
+
+    const finished = (async () => {
+      try {
+        await queryCodex(
+          promptText,
+          {
+            cwd: ctx.cwd,
+            permissionMode: ctx.permissionMode ?? 'default',
+          },
+          fakeWriter,
+        );
+
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'completed');
+        }
+      } catch (err) {
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'failed', {
+            code: 'ADAPTER_RUNTIME_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } finally {
+        this.active.delete(task.id);
+      }
+    })();
+
+    return {
+      cancel: () => this.cancelTask(task.id),
+      finished,
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<void> {
+    const session = this.active.get(taskId);
+    if (!session) {
+      this.emitState(taskId, 'canceled');
+      return;
+    }
+
+    this.active.delete(taskId);
+    if (session.sessionId) {
+      abortCodexSession(session.sessionId);
+    }
+    this.emitState(taskId, 'canceled');
+  }
+
+  private handleRuntimeFrame(
+    taskId: string,
+    frame: unknown,
+    session: { sessionId: string | null },
+  ): void {
+    if (!frame || typeof frame !== 'object') return;
+    const message = frame as Partial<NormalizedMessage>;
+
+    if (
+      message.kind === 'session_created' &&
+      typeof message.newSessionId === 'string' &&
+      !session.sessionId
+    ) {
+      session.sessionId = message.newSessionId;
+      return;
+    }
+
+    switch (message.kind) {
+      case 'text': {
+        const text = typeof message.content === 'string' ? message.content : null;
+        if (text && text.trim()) {
+          this.emitMessage(taskId, {
+            messageId: typeof message.id === 'string' ? message.id : newId('msg'),
+            role: message.role === 'user' ? 'user' : 'agent',
+            parts: [{ kind: 'text', text }],
+            taskId,
+          });
+        }
+        return;
+      }
+
+      case 'thinking': {
+        const text = typeof message.content === 'string' ? message.content : '';
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: { kind: 'thinking', text } }],
+          metadata: { source: 'codex-thinking' },
+        });
+        return;
+      }
+
+      case 'tool_use': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolName: message.toolName,
+                toolInput: message.toolInput,
+                toolResult: message.toolResult,
+                output: message.output,
+                exitCode: message.exitCode,
+                status: message.status,
+              },
+            },
+          ],
+          metadata: { source: 'codex-tool-use' },
+        });
+        return;
+      }
+
+      case 'tool_result': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolId: message.toolId,
+                content: message.content,
+                isError: message.isError,
+                toolUseResult: message.toolUseResult,
+              },
+            },
+          ],
+          metadata: { source: 'codex-tool-result' },
+        });
+        return;
+      }
+
+      case 'status':
+      case 'stream_delta':
+      case 'stream_end':
+      case 'complete':
+      case 'session_created':
+        return;
+
+      case 'error': {
+        const text =
+          typeof message.content === 'string' && message.content.length > 0
+            ? message.content
+            : 'Codex reported an error';
+        this.emitState(taskId, 'failed', {
+          code: 'ADAPTER_RUNTIME_ERROR',
+          message: text,
+        });
+        this.active.delete(taskId);
+        return;
+      }
+
+      default: {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: message as Record<string, unknown> }],
+          metadata: { source: `codex-${String(message.kind ?? 'event')}` },
+        });
+      }
+    }
+  }
+}

--- a/server/modules/orchestration/a2a/adapters/cursor.adapter.ts
+++ b/server/modules/orchestration/a2a/adapters/cursor.adapter.ts
@@ -1,0 +1,247 @@
+// server/modules/orchestration/a2a/adapters/cursor.adapter.ts
+// Wraps the existing server/cursor-cli.js runtime, which emits
+// provider-neutral NormalizedMessage frames over a writer interface.
+
+import crypto from 'node:crypto';
+
+// eslint-disable-next-line boundaries/no-unknown -- cursor-cli.js is a top-level CLI runtime not yet classified by eslint.config.js; cleanup deferred.
+import { abortCursorSession, spawnCursor } from '@/cursor-cli.js';
+import { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type {
+  AdapterContext,
+  TaskHandle,
+} from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type { AgentCard, Part, Task } from '@/modules/orchestration/a2a/types.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+interface FakeWriter {
+  send(data: unknown): void;
+  getSessionId(): string | null;
+  setSessionId(sessionId: string): void;
+}
+
+function joinPartsToPrompt(parts: Part[]): string {
+  return parts
+    .map((part) => {
+      if (part.kind === 'text') return part.text;
+      if (part.kind === 'data') return JSON.stringify(part.data);
+      return `[file:${part.name}${part.uri ? ` uri=${part.uri}` : ''}]`;
+    })
+    .join('\n');
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export class CursorA2AAdapter extends AbstractA2AAdapter {
+  readonly id = 'cursor';
+
+  readonly agentCard: AgentCard = {
+    name: 'pixcode-cursor',
+    description: 'Cursor CLI, accessed via Pixcode',
+    url: '/a2a/agents/cursor',
+    version: '1.0.0',
+    capabilities: ['streaming', 'fileEdit', 'commandExec'],
+    skills: [
+      {
+        id: 'rapid-prototyping',
+        description: 'Fast implementation for coding tasks in Cursor CLI',
+      },
+      {
+        id: 'reasoning-assist',
+        description: 'Emit reasoning and tool traces during execution',
+      },
+      {
+        id: 'multi-file-refactor',
+        description: 'Coordinate edits across multiple files',
+      },
+    ],
+    authentication: { type: 'bearer' },
+  };
+
+  private readonly active = new Map<string, { sessionId: string | null }>();
+
+  async submitTask(task: Task, ctx: AdapterContext): Promise<TaskHandle> {
+    const promptText = joinPartsToPrompt(
+      task.history[task.history.length - 1]?.parts ?? [],
+    );
+    const session = { sessionId: null as string | null };
+    this.active.set(task.id, session);
+
+    this.emitState(task.id, 'working');
+
+    const fakeWriter: FakeWriter = {
+      send: (data) => this.handleRuntimeFrame(task.id, data, session),
+      getSessionId: () => session.sessionId,
+      setSessionId: (sessionId) => {
+        session.sessionId = sessionId;
+      },
+    };
+
+    const finished = (async () => {
+      try {
+        await spawnCursor(
+          promptText,
+          {
+            cwd: ctx.cwd,
+            skipPermissions:
+              ctx.permissionMode === 'acceptEdits' || ctx.permissionMode === 'bypassPermissions',
+          },
+          fakeWriter,
+        );
+
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'completed');
+        }
+      } catch (err) {
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'failed', {
+            code: 'ADAPTER_RUNTIME_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } finally {
+        this.active.delete(task.id);
+      }
+    })();
+
+    return {
+      cancel: () => this.cancelTask(task.id),
+      finished,
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<void> {
+    const session = this.active.get(taskId);
+    if (!session) {
+      this.emitState(taskId, 'canceled');
+      return;
+    }
+
+    this.active.delete(taskId);
+    if (session.sessionId) {
+      abortCursorSession(session.sessionId);
+    }
+    this.emitState(taskId, 'canceled');
+  }
+
+  private handleRuntimeFrame(
+    taskId: string,
+    frame: unknown,
+    session: { sessionId: string | null },
+  ): void {
+    if (!frame || typeof frame !== 'object') return;
+    const message = frame as Partial<NormalizedMessage>;
+
+    if (
+      message.kind === 'session_created' &&
+      typeof message.newSessionId === 'string' &&
+      !session.sessionId
+    ) {
+      session.sessionId = message.newSessionId;
+      return;
+    }
+
+    switch (message.kind) {
+      case 'stream_delta':
+      case 'text': {
+        const text = typeof message.content === 'string' ? message.content : null;
+        if (text && text.trim()) {
+          this.emitMessage(taskId, {
+            messageId: typeof message.id === 'string' ? message.id : newId('msg'),
+            role: message.role === 'user' ? 'user' : 'agent',
+            parts: [{ kind: 'text', text }],
+            taskId,
+          });
+        }
+        return;
+      }
+
+      case 'thinking': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                kind: 'thinking',
+                content: message.content,
+              },
+            },
+          ],
+          metadata: { source: 'cursor-thinking' },
+        });
+        return;
+      }
+
+      case 'tool_use': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolName: message.toolName,
+                toolInput: message.toolInput,
+                toolId: message.toolId,
+                toolResult: message.toolResult,
+              },
+            },
+          ],
+          metadata: { source: 'cursor-tool-use' },
+        });
+        return;
+      }
+
+      case 'tool_result': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolId: message.toolId,
+                content: message.content,
+                isError: message.isError,
+              },
+            },
+          ],
+          metadata: { source: 'cursor-tool-result' },
+        });
+        return;
+      }
+
+      case 'status':
+      case 'stream_end':
+      case 'complete':
+      case 'session_created':
+        return;
+
+      case 'error': {
+        const text =
+          typeof message.content === 'string' && message.content.length > 0
+            ? message.content
+            : 'Cursor reported an error';
+        this.emitState(taskId, 'failed', {
+          code: 'ADAPTER_RUNTIME_ERROR',
+          message: text,
+        });
+        this.active.delete(taskId);
+        return;
+      }
+
+      default: {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: message as Record<string, unknown> }],
+          metadata: { source: `cursor-${String(message.kind ?? 'event')}` },
+        });
+      }
+    }
+  }
+}

--- a/server/modules/orchestration/a2a/adapters/gemini.adapter.ts
+++ b/server/modules/orchestration/a2a/adapters/gemini.adapter.ts
@@ -1,0 +1,246 @@
+// server/modules/orchestration/a2a/adapters/gemini.adapter.ts
+// Wraps the existing server/gemini-cli.js runtime, which emits
+// provider-neutral NormalizedMessage frames over a writer interface.
+
+import crypto from 'node:crypto';
+
+// eslint-disable-next-line boundaries/no-unknown -- gemini-cli.js is a top-level CLI runtime not yet classified by eslint.config.js; cleanup deferred.
+import { abortGeminiSession, spawnGemini } from '@/gemini-cli.js';
+import { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type {
+  AdapterContext,
+  TaskHandle,
+} from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type { AgentCard, Part, Task } from '@/modules/orchestration/a2a/types.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+interface FakeWriter {
+  send(data: unknown): void;
+  getSessionId(): string | null;
+  setSessionId(sessionId: string): void;
+}
+
+function joinPartsToPrompt(parts: Part[]): string {
+  return parts
+    .map((part) => {
+      if (part.kind === 'text') return part.text;
+      if (part.kind === 'data') return JSON.stringify(part.data);
+      return `[file:${part.name}${part.uri ? ` uri=${part.uri}` : ''}]`;
+    })
+    .join('\n');
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export class GeminiA2AAdapter extends AbstractA2AAdapter {
+  readonly id = 'gemini';
+
+  readonly agentCard: AgentCard = {
+    name: 'pixcode-gemini',
+    description: 'Google Gemini CLI, accessed via Pixcode',
+    url: '/a2a/agents/gemini',
+    version: '1.0.0',
+    capabilities: ['streaming', 'fileEdit', 'commandExec', 'mcp'],
+    skills: [
+      {
+        id: 'rapid-prototyping',
+        description: 'Fast implementation and iteration for coding tasks',
+      },
+      {
+        id: 'tool-augmented-editing',
+        description: 'Use CLI tools and MCP servers while editing code',
+      },
+      {
+        id: 'multi-file-refactor',
+        description: 'Coordinate edits across multiple files',
+      },
+    ],
+    authentication: { type: 'bearer' },
+  };
+
+  private readonly active = new Map<string, { sessionId: string | null }>();
+
+  async submitTask(task: Task, ctx: AdapterContext): Promise<TaskHandle> {
+    const promptText = joinPartsToPrompt(
+      task.history[task.history.length - 1]?.parts ?? [],
+    );
+    const session = { sessionId: null as string | null };
+    this.active.set(task.id, session);
+
+    this.emitState(task.id, 'working');
+
+    const fakeWriter: FakeWriter = {
+      send: (data) => this.handleRuntimeFrame(task.id, data, session),
+      getSessionId: () => session.sessionId,
+      setSessionId: (sessionId) => {
+        session.sessionId = sessionId;
+      },
+    };
+
+    const finished = (async () => {
+      try {
+        await spawnGemini(
+          promptText,
+          {
+            cwd: ctx.cwd,
+            permissionMode: ctx.permissionMode === 'bypassPermissions' ? 'yolo' : ctx.permissionMode,
+          },
+          fakeWriter,
+        );
+
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'completed');
+        }
+      } catch (err) {
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'failed', {
+            code: 'ADAPTER_RUNTIME_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } finally {
+        this.active.delete(task.id);
+      }
+    })();
+
+    return {
+      cancel: () => this.cancelTask(task.id),
+      finished,
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<void> {
+    const session = this.active.get(taskId);
+    if (!session) {
+      this.emitState(taskId, 'canceled');
+      return;
+    }
+
+    this.active.delete(taskId);
+    if (session.sessionId) {
+      abortGeminiSession(session.sessionId);
+    }
+    this.emitState(taskId, 'canceled');
+  }
+
+  private handleRuntimeFrame(
+    taskId: string,
+    frame: unknown,
+    session: { sessionId: string | null },
+  ): void {
+    if (!frame || typeof frame !== 'object') return;
+    const message = frame as Partial<NormalizedMessage>;
+
+    if (
+      message.kind === 'session_created' &&
+      typeof message.newSessionId === 'string' &&
+      !session.sessionId
+    ) {
+      session.sessionId = message.newSessionId;
+      return;
+    }
+
+    switch (message.kind) {
+      case 'stream_delta':
+      case 'text': {
+        const text = typeof message.content === 'string' ? message.content : null;
+        if (text && text.trim()) {
+          this.emitMessage(taskId, {
+            messageId: typeof message.id === 'string' ? message.id : newId('msg'),
+            role: 'agent',
+            parts: [{ kind: 'text', text }],
+            taskId,
+          });
+        }
+        return;
+      }
+
+      case 'tool_use': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolName: message.toolName,
+                toolInput: message.toolInput,
+                toolId: message.toolId,
+                toolResult: message.toolResult,
+              },
+            },
+          ],
+          metadata: { source: 'gemini-tool-use' },
+        });
+        return;
+      }
+
+      case 'tool_result': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolId: message.toolId,
+                content: message.content,
+                isError: message.isError,
+              },
+            },
+          ],
+          metadata: { source: 'gemini-tool-result' },
+        });
+        return;
+      }
+
+      case 'status': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                kind: 'status',
+                text: message.text,
+                tokens: message.tokens,
+              },
+            },
+          ],
+          metadata: { source: 'gemini-status' },
+        });
+        return;
+      }
+
+      case 'stream_end':
+      case 'complete':
+      case 'session_created':
+        return;
+
+      case 'error': {
+        const text =
+          typeof message.content === 'string' && message.content.length > 0
+            ? message.content
+            : 'Gemini reported an error';
+        this.emitState(taskId, 'failed', {
+          code: 'ADAPTER_RUNTIME_ERROR',
+          message: text,
+        });
+        this.active.delete(taskId);
+        return;
+      }
+
+      default: {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: message as Record<string, unknown> }],
+          metadata: { source: `gemini-${String(message.kind ?? 'event')}` },
+        });
+      }
+    }
+  }
+}

--- a/server/modules/orchestration/a2a/adapters/opencode.adapter.ts
+++ b/server/modules/orchestration/a2a/adapters/opencode.adapter.ts
@@ -1,0 +1,246 @@
+// server/modules/orchestration/a2a/adapters/opencode.adapter.ts
+// Wraps the existing server/opencode-cli.js runtime, which emits
+// provider-neutral NormalizedMessage frames over a writer interface.
+
+import crypto from 'node:crypto';
+
+// eslint-disable-next-line boundaries/no-unknown -- opencode-cli.js is a top-level CLI runtime not yet classified by eslint.config.js; cleanup deferred.
+import { abortOpencodeSession, spawnOpencode } from '@/opencode-cli.js';
+import { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type {
+  AdapterContext,
+  TaskHandle,
+} from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type { AgentCard, Part, Task } from '@/modules/orchestration/a2a/types.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+interface FakeWriter {
+  send(data: unknown): void;
+  getSessionId(): string | null;
+  setSessionId(sessionId: string): void;
+}
+
+function joinPartsToPrompt(parts: Part[]): string {
+  return parts
+    .map((part) => {
+      if (part.kind === 'text') return part.text;
+      if (part.kind === 'data') return JSON.stringify(part.data);
+      return `[file:${part.name}${part.uri ? ` uri=${part.uri}` : ''}]`;
+    })
+    .join('\n');
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export class OpenCodeA2AAdapter extends AbstractA2AAdapter {
+  readonly id = 'opencode';
+
+  readonly agentCard: AgentCard = {
+    name: 'pixcode-opencode',
+    description: 'OpenCode CLI, accessed via Pixcode',
+    url: '/a2a/agents/opencode',
+    version: '1.0.0',
+    capabilities: ['streaming', 'fileEdit', 'commandExec', 'multiProvider'],
+    skills: [
+      {
+        id: 'rapid-prototyping',
+        description: 'Fast implementation with multi-provider CLI routing',
+      },
+      {
+        id: 'plan-mode',
+        description: 'Read-only planning mode for change proposals',
+      },
+      {
+        id: 'tool-augmented-editing',
+        description: 'Use CLI tools while editing code across a workspace',
+      },
+    ],
+    authentication: { type: 'bearer' },
+  };
+
+  private readonly active = new Map<string, { sessionId: string | null }>();
+
+  async submitTask(task: Task, ctx: AdapterContext): Promise<TaskHandle> {
+    const promptText = joinPartsToPrompt(
+      task.history[task.history.length - 1]?.parts ?? [],
+    );
+    const session = { sessionId: null as string | null };
+    this.active.set(task.id, session);
+
+    this.emitState(task.id, 'working');
+
+    const fakeWriter: FakeWriter = {
+      send: (data) => this.handleRuntimeFrame(task.id, data, session),
+      getSessionId: () => session.sessionId,
+      setSessionId: (sessionId) => {
+        session.sessionId = sessionId;
+      },
+    };
+
+    const finished = (async () => {
+      try {
+        await spawnOpencode(
+          promptText,
+          {
+            cwd: ctx.cwd,
+            permissionMode: ctx.permissionMode,
+          },
+          fakeWriter,
+        );
+
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'completed');
+        }
+      } catch (err) {
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'failed', {
+            code: 'ADAPTER_RUNTIME_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } finally {
+        this.active.delete(task.id);
+      }
+    })();
+
+    return {
+      cancel: () => this.cancelTask(task.id),
+      finished,
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<void> {
+    const session = this.active.get(taskId);
+    if (!session) {
+      this.emitState(taskId, 'canceled');
+      return;
+    }
+
+    this.active.delete(taskId);
+    if (session.sessionId) {
+      abortOpencodeSession(session.sessionId);
+    }
+    this.emitState(taskId, 'canceled');
+  }
+
+  private handleRuntimeFrame(
+    taskId: string,
+    frame: unknown,
+    session: { sessionId: string | null },
+  ): void {
+    if (!frame || typeof frame !== 'object') return;
+    const message = frame as Partial<NormalizedMessage>;
+
+    if (
+      message.kind === 'session_created' &&
+      typeof message.newSessionId === 'string' &&
+      !session.sessionId
+    ) {
+      session.sessionId = message.newSessionId;
+      return;
+    }
+
+    switch (message.kind) {
+      case 'stream_delta':
+      case 'text': {
+        const text = typeof message.content === 'string' ? message.content : null;
+        if (text && text.trim()) {
+          this.emitMessage(taskId, {
+            messageId: typeof message.id === 'string' ? message.id : newId('msg'),
+            role: 'agent',
+            parts: [{ kind: 'text', text }],
+            taskId,
+          });
+        }
+        return;
+      }
+
+      case 'tool_use': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolName: message.toolName,
+                toolInput: message.toolInput,
+                toolId: message.toolId,
+                toolResult: message.toolResult,
+              },
+            },
+          ],
+          metadata: { source: 'opencode-tool-use' },
+        });
+        return;
+      }
+
+      case 'tool_result': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolId: message.toolId,
+                content: message.content,
+                isError: message.isError,
+              },
+            },
+          ],
+          metadata: { source: 'opencode-tool-result' },
+        });
+        return;
+      }
+
+      case 'status': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                kind: 'status',
+                text: message.text,
+                tokens: message.tokens,
+              },
+            },
+          ],
+          metadata: { source: 'opencode-status' },
+        });
+        return;
+      }
+
+      case 'stream_end':
+      case 'complete':
+      case 'session_created':
+        return;
+
+      case 'error': {
+        const text =
+          typeof message.content === 'string' && message.content.length > 0
+            ? message.content
+            : 'OpenCode reported an error';
+        this.emitState(taskId, 'failed', {
+          code: 'ADAPTER_RUNTIME_ERROR',
+          message: text,
+        });
+        this.active.delete(taskId);
+        return;
+      }
+
+      default: {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: message as Record<string, unknown> }],
+          metadata: { source: `opencode-${String(message.kind ?? 'event')}` },
+        });
+      }
+    }
+  }
+}

--- a/server/modules/orchestration/a2a/adapters/qwen.adapter.ts
+++ b/server/modules/orchestration/a2a/adapters/qwen.adapter.ts
@@ -1,0 +1,246 @@
+// server/modules/orchestration/a2a/adapters/qwen.adapter.ts
+// Wraps the existing server/qwen-code-cli.js runtime, which emits
+// provider-neutral NormalizedMessage frames over a writer interface.
+
+import crypto from 'node:crypto';
+
+// eslint-disable-next-line boundaries/no-unknown -- qwen-code-cli.js is a top-level CLI runtime not yet classified by eslint.config.js; cleanup deferred.
+import { abortQwenSession, spawnQwen } from '@/qwen-code-cli.js';
+import { AbstractA2AAdapter } from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type {
+  AdapterContext,
+  TaskHandle,
+} from '@/modules/orchestration/a2a/adapters/abstract-a2a.adapter.js';
+import type { AgentCard, Part, Task } from '@/modules/orchestration/a2a/types.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+interface FakeWriter {
+  send(data: unknown): void;
+  getSessionId(): string | null;
+  setSessionId(sessionId: string): void;
+}
+
+function joinPartsToPrompt(parts: Part[]): string {
+  return parts
+    .map((part) => {
+      if (part.kind === 'text') return part.text;
+      if (part.kind === 'data') return JSON.stringify(part.data);
+      return `[file:${part.name}${part.uri ? ` uri=${part.uri}` : ''}]`;
+    })
+    .join('\n');
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+export class QwenA2AAdapter extends AbstractA2AAdapter {
+  readonly id = 'qwen';
+
+  readonly agentCard: AgentCard = {
+    name: 'pixcode-qwen',
+    description: 'Qwen Code CLI, accessed via Pixcode',
+    url: '/a2a/agents/qwen',
+    version: '1.0.0',
+    capabilities: ['streaming', 'fileEdit', 'commandExec', 'mcp'],
+    skills: [
+      {
+        id: 'rapid-prototyping',
+        description: 'Fast implementation and iteration for coding tasks',
+      },
+      {
+        id: 'tool-augmented-editing',
+        description: 'Use CLI tools and MCP servers while editing code',
+      },
+      {
+        id: 'multi-file-refactor',
+        description: 'Coordinate edits across multiple files',
+      },
+    ],
+    authentication: { type: 'bearer' },
+  };
+
+  private readonly active = new Map<string, { sessionId: string | null }>();
+
+  async submitTask(task: Task, ctx: AdapterContext): Promise<TaskHandle> {
+    const promptText = joinPartsToPrompt(
+      task.history[task.history.length - 1]?.parts ?? [],
+    );
+    const session = { sessionId: null as string | null };
+    this.active.set(task.id, session);
+
+    this.emitState(task.id, 'working');
+
+    const fakeWriter: FakeWriter = {
+      send: (data) => this.handleRuntimeFrame(task.id, data, session),
+      getSessionId: () => session.sessionId,
+      setSessionId: (sessionId) => {
+        session.sessionId = sessionId;
+      },
+    };
+
+    const finished = (async () => {
+      try {
+        await spawnQwen(
+          promptText,
+          {
+            cwd: ctx.cwd,
+            permissionMode: ctx.permissionMode === 'bypassPermissions' ? 'yolo' : ctx.permissionMode,
+          },
+          fakeWriter,
+        );
+
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'completed');
+        }
+      } catch (err) {
+        if (this.active.has(task.id)) {
+          this.emitState(task.id, 'failed', {
+            code: 'ADAPTER_RUNTIME_ERROR',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } finally {
+        this.active.delete(task.id);
+      }
+    })();
+
+    return {
+      cancel: () => this.cancelTask(task.id),
+      finished,
+    };
+  }
+
+  async cancelTask(taskId: string): Promise<void> {
+    const session = this.active.get(taskId);
+    if (!session) {
+      this.emitState(taskId, 'canceled');
+      return;
+    }
+
+    this.active.delete(taskId);
+    if (session.sessionId) {
+      abortQwenSession(session.sessionId);
+    }
+    this.emitState(taskId, 'canceled');
+  }
+
+  private handleRuntimeFrame(
+    taskId: string,
+    frame: unknown,
+    session: { sessionId: string | null },
+  ): void {
+    if (!frame || typeof frame !== 'object') return;
+    const message = frame as Partial<NormalizedMessage>;
+
+    if (
+      message.kind === 'session_created' &&
+      typeof message.newSessionId === 'string' &&
+      !session.sessionId
+    ) {
+      session.sessionId = message.newSessionId;
+      return;
+    }
+
+    switch (message.kind) {
+      case 'stream_delta':
+      case 'text': {
+        const text = typeof message.content === 'string' ? message.content : null;
+        if (text && text.trim()) {
+          this.emitMessage(taskId, {
+            messageId: typeof message.id === 'string' ? message.id : newId('msg'),
+            role: 'agent',
+            parts: [{ kind: 'text', text }],
+            taskId,
+          });
+        }
+        return;
+      }
+
+      case 'tool_use': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolName: message.toolName,
+                toolInput: message.toolInput,
+                toolId: message.toolId,
+                toolResult: message.toolResult,
+              },
+            },
+          ],
+          metadata: { source: 'qwen-tool-use' },
+        });
+        return;
+      }
+
+      case 'tool_result': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'command-output',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                toolId: message.toolId,
+                content: message.content,
+                isError: message.isError,
+              },
+            },
+          ],
+          metadata: { source: 'qwen-tool-result' },
+        });
+        return;
+      }
+
+      case 'status': {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [
+            {
+              kind: 'data',
+              data: {
+                kind: 'status',
+                text: message.text,
+                tokens: message.tokens,
+              },
+            },
+          ],
+          metadata: { source: 'qwen-status' },
+        });
+        return;
+      }
+
+      case 'stream_end':
+      case 'complete':
+      case 'session_created':
+        return;
+
+      case 'error': {
+        const text =
+          typeof message.content === 'string' && message.content.length > 0
+            ? message.content
+            : 'Qwen reported an error';
+        this.emitState(taskId, 'failed', {
+          code: 'ADAPTER_RUNTIME_ERROR',
+          message: text,
+        });
+        this.active.delete(taskId);
+        return;
+      }
+
+      default: {
+        this.emitArtifact(taskId, {
+          artifactId: typeof message.id === 'string' ? message.id : newId('art'),
+          type: 'data',
+          parts: [{ kind: 'data', data: message as Record<string, unknown> }],
+          metadata: { source: `qwen-${String(message.kind ?? 'event')}` },
+        });
+      }
+    }
+  }
+}

--- a/server/modules/orchestration/a2a/routes.ts
+++ b/server/modules/orchestration/a2a/routes.ts
@@ -10,6 +10,7 @@ import { adapterRegistry } from '@/modules/orchestration/a2a/adapter-registry.js
 import { buildPixcodeAgentCard } from '@/modules/orchestration/a2a/agent-card.js';
 import { a2aAuth } from '@/modules/orchestration/a2a/auth.middleware.js';
 import { a2aBus } from '@/modules/orchestration/a2a/bus.js';
+import { A2ATaskStore } from '@/modules/orchestration/a2a/task-store.js';
 import type {
   BusEvent,
   Message,
@@ -22,18 +23,43 @@ import {
   assertSubmitTaskInput,
 } from '@/modules/orchestration/a2a/validator.js';
 
-// In-memory task store. Persistence is out of scope for the foundation;
-// a follow-on plan adds SQLite-backed storage.
-const tasks = new Map<string, Task>();
+type RoutingHints = {
+  preferredAdapterId?: string;
+  preferredProvider?: string;
+  preferredSkillId?: string;
+};
+
+function readRoutingHints(value: unknown): RoutingHints {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const source = value as Record<string, unknown>;
+  return {
+    preferredAdapterId:
+      typeof source.preferredAdapterId === 'string' ? source.preferredAdapterId : undefined,
+    preferredProvider:
+      typeof source.preferredProvider === 'string' ? source.preferredProvider : undefined,
+    preferredSkillId:
+      typeof source.preferredSkillId === 'string' ? source.preferredSkillId : undefined,
+  };
+}
+
+const TERMINAL: TaskState[] = ['completed', 'canceled', 'failed'];
 // Per-task bus unsubscribe handles; called on terminal state.
 const taskUnsubs = new Map<string, () => void>();
 // Eviction timeouts (terminal tasks live for 1 hour before being purged).
 const taskEvictions = new Map<string, NodeJS.Timeout>();
 const TERMINAL_TASK_TTL_MS = 60 * 60 * 1000; // 1 hour
 const MAX_TASKS = 1000;
+const taskStore = new A2ATaskStore({ terminalTaskTtlMs: TERMINAL_TASK_TTL_MS });
 
 function newId(prefix: string): string {
   return `${prefix}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function isTerminalTaskState(state: TaskState): boolean {
+  return TERMINAL.includes(state);
 }
 
 function getBaseUrl(req: Request): string {
@@ -45,38 +71,94 @@ function getBaseUrl(req: Request): string {
   return `${proto}://${host}`;
 }
 
+function scheduleTaskEviction(taskId: string): void {
+  const existingTimeout = taskEvictions.get(taskId);
+  if (existingTimeout) {
+    clearTimeout(existingTimeout);
+  }
+
+  const task = taskStore.get(taskId);
+  if (!task) {
+    taskEvictions.delete(taskId);
+    return;
+  }
+
+  const remainingMs = Math.max(0, task.updatedAt + TERMINAL_TASK_TTL_MS - Date.now());
+  taskEvictions.set(
+    taskId,
+    setTimeout(() => {
+      taskStore.delete(taskId);
+      taskEvictions.delete(taskId);
+    }, remainingMs),
+  );
+}
+
+function parseTaskState(value: unknown): TaskState | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (
+    normalized === 'submitted' ||
+    normalized === 'working' ||
+    normalized === 'input-required' ||
+    normalized === 'completed' ||
+    normalized === 'canceled' ||
+    normalized === 'failed'
+  ) {
+    return normalized;
+  }
+
+  return undefined;
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
 function attachBusToTask(task: Task): void {
   const unsubscribe = a2aBus.subscribe(task.id, (event: BusEvent) => {
     if (event.kind === 'task-state') {
       task.state = event.state;
       if (event.error) task.error = event.error;
       task.updatedAt = Date.now();
-      if (event.state === 'completed' || event.state === 'canceled' || event.state === 'failed') {
+      taskStore.set(task);
+      if (isTerminalTaskState(event.state)) {
         // Release the listener; schedule eviction.
         const unsub = taskUnsubs.get(task.id);
         if (unsub) {
           unsub();
           taskUnsubs.delete(task.id);
         }
-        const existingTimeout = taskEvictions.get(task.id);
-        if (existingTimeout) clearTimeout(existingTimeout);
-        taskEvictions.set(
-          task.id,
-          setTimeout(() => {
-            tasks.delete(task.id);
-            taskEvictions.delete(task.id);
-          }, TERMINAL_TASK_TTL_MS),
-        );
+        scheduleTaskEviction(task.id);
       }
     } else if (event.kind === 'message') {
       task.history.push(event.message);
       task.updatedAt = Date.now();
+      taskStore.set(task);
     } else if (event.kind === 'artifact') {
       task.artifacts.push(event.artifact);
       task.updatedAt = Date.now();
+      taskStore.set(task);
     }
   });
   taskUnsubs.set(task.id, unsubscribe);
+}
+
+for (const task of taskStore.values()) {
+  if (isTerminalTaskState(task.state)) {
+    scheduleTaskEviction(task.id);
+  }
 }
 
 export function createA2ARouter(): Router {
@@ -103,6 +185,57 @@ export function createA2ARouter(): Router {
     res.json(adapter.agentCard);
   });
 
+  router.post('/adapters/resolve', (req, res) => {
+    const selector = typeof req.body?.adapterId === 'string' ? req.body.adapterId : '';
+    if (!selector.trim()) {
+      res.status(400).json({
+        error: { code: 'ADAPTER_ID_REQUIRED', message: 'adapterId is required.' },
+      });
+      return;
+    }
+
+    const routing = readRoutingHints(req.body?.routing);
+    const adapter = adapterRegistry.resolve(selector, routing);
+    if (!adapter) {
+      res.status(404).json({
+        error: {
+          code: 'ADAPTER_NOT_FOUND',
+          message: selector,
+          availableAdapters: adapterRegistry.list().map((candidate) => candidate.id),
+        },
+      });
+      return;
+    }
+
+    res.json({
+      selector,
+      resolvedAdapterId: adapter.id,
+      agentCard: adapter.agentCard,
+    });
+  });
+
+  router.get('/tasks', (req, res) => {
+    const state = parseTaskState(req.query.state);
+    const contextId = typeof req.query.contextId === 'string' ? req.query.contextId : undefined;
+    const adapterId = typeof req.query.adapterId === 'string' ? req.query.adapterId : undefined;
+    const limit = parsePositiveInt(req.query.limit, 50);
+
+    const tasks = taskStore
+      .list({ state, contextId, adapterId, limit })
+      .map((task) => taskStore.summarize(task));
+
+    res.json({
+      tasks,
+      count: tasks.length,
+      filters: {
+        state,
+        contextId,
+        adapterId,
+        limit,
+      },
+    });
+  });
+
   // Task lifecycle
   router.post('/tasks', async (req: Request, res: Response) => {
     try {
@@ -113,20 +246,27 @@ export function createA2ARouter(): Router {
       return;
     }
 
-    const adapter = adapterRegistry.get(req.body.adapterId);
+    const metadata = req.body.metadata as Record<string, unknown> | undefined;
+    const routing = readRoutingHints(metadata?.routing);
+
+    const adapter = adapterRegistry.resolve(req.body.adapterId, routing);
     if (!adapter) {
       res.status(404).json({
-        error: { code: 'ADAPTER_NOT_FOUND', message: req.body.adapterId },
+        error: {
+          code: 'ADAPTER_NOT_FOUND',
+          message: req.body.adapterId,
+          availableAdapters: adapterRegistry.list().map((candidate) => candidate.id),
+        },
       });
       return;
     }
 
     // Enforce MAX_TASKS cap. Evict the oldest terminal task first; if all
     // active, fail closed with 503.
-    if (tasks.size >= MAX_TASKS) {
+    if (taskStore.size >= MAX_TASKS) {
       let evicted = false;
-      for (const [tid, t] of tasks) {
-        if (t.state === 'completed' || t.state === 'canceled' || t.state === 'failed') {
+      for (const [tid, t] of taskStore.entries()) {
+        if (isTerminalTaskState(t.state)) {
           const timeout = taskEvictions.get(tid);
           if (timeout) clearTimeout(timeout);
           taskEvictions.delete(tid);
@@ -135,7 +275,7 @@ export function createA2ARouter(): Router {
             unsub();
             taskUnsubs.delete(tid);
           }
-          tasks.delete(tid);
+          taskStore.delete(tid);
           evicted = true;
           break;
         }
@@ -153,16 +293,21 @@ export function createA2ARouter(): Router {
       id: newId('task'),
       contextId: req.body.contextId,
       state: 'submitted',
-      history: [userMessage],
+      history: [],
       artifacts: [],
       metadata: req.body.metadata,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    tasks.set(task.id, task);
+    task.history.push({ ...userMessage, taskId: task.id });
     // Persist adapterId in metadata so cancel can resolve the owning adapter
     // even when the original request body is no longer available.
-    task.metadata = { ...task.metadata, adapterId: req.body.adapterId };
+    task.metadata = {
+      ...task.metadata,
+      adapterId: adapter.id,
+      adapterSelector: req.body.adapterId,
+    };
+    taskStore.set(task);
     attachBusToTask(task);
 
     try {
@@ -186,7 +331,7 @@ export function createA2ARouter(): Router {
   });
 
   router.get('/tasks/:id', (req, res) => {
-    const task = tasks.get(req.params.id);
+    const task = taskStore.get(req.params.id);
     if (!task) {
       res.status(404).json({ error: { code: 'TASK_NOT_FOUND', message: req.params.id } });
       return;
@@ -195,7 +340,7 @@ export function createA2ARouter(): Router {
   });
 
   router.get('/tasks/:id/stream', (req, res) => {
-    const task = tasks.get(req.params.id);
+    const task = taskStore.get(req.params.id);
     if (!task) {
       res.status(404).json({ error: { code: 'TASK_NOT_FOUND', message: req.params.id } });
       return;
@@ -209,7 +354,6 @@ export function createA2ARouter(): Router {
     const initial = { kind: 'task-snapshot' as const, task };
     res.write(`event: snapshot\ndata: ${JSON.stringify(initial)}\n\n`);
 
-    const TERMINAL: TaskState[] = ['completed', 'canceled', 'failed'];
     const unsubscribe = a2aBus.subscribe(task.id, (event) => {
       res.write(`event: ${event.kind}\ndata: ${JSON.stringify(event)}\n\n`);
       if (event.kind === 'task-state' && TERMINAL.includes(event.state)) {
@@ -223,14 +367,14 @@ export function createA2ARouter(): Router {
   });
 
   router.post('/tasks/:id/cancel', async (req, res) => {
-    const task = tasks.get(req.params.id);
+    const task = taskStore.get(req.params.id);
     if (!task) {
       res.status(404).json({ error: { code: 'TASK_NOT_FOUND', message: req.params.id } });
       return;
     }
     // Look up the adapter that owns this task. We stored adapterId in metadata.
     const adapterId = req.body?.adapterId ?? task.metadata?.adapterId;
-    const adapter = typeof adapterId === 'string' ? adapterRegistry.get(adapterId) : undefined;
+    const adapter = typeof adapterId === 'string' ? adapterRegistry.resolve(adapterId) : undefined;
     if (!adapter) {
       res.status(400).json({
         error: {
@@ -241,7 +385,7 @@ export function createA2ARouter(): Router {
       return;
     }
     await adapter.cancelTask(task.id);
-    res.json(tasks.get(task.id));
+    res.json(taskStore.get(task.id));
   });
 
   router.post('/messages', (req, res) => {
@@ -250,6 +394,12 @@ export function createA2ARouter(): Router {
     } catch (err) {
       const e = err as A2AValidationError;
       res.status(400).json({ error: { code: 'INVALID_INPUT', message: e.message, path: e.path } });
+      return;
+    }
+    if (typeof req.body.taskId === 'string' && !taskStore.get(req.body.taskId)) {
+      res.status(404).json({
+        error: { code: 'TASK_NOT_FOUND', message: req.body.taskId },
+      });
       return;
     }
     a2aBus.publish({

--- a/server/modules/orchestration/a2a/task-store.ts
+++ b/server/modules/orchestration/a2a/task-store.ts
@@ -1,0 +1,211 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { Task, TaskSummary, TaskState } from '@/modules/orchestration/a2a/types.js';
+
+interface PersistedTaskDocument {
+  version: 1;
+  tasks: Task[];
+}
+
+const DOCUMENT_VERSION = 1;
+const TERMINAL_STATES = new Set(['completed', 'canceled', 'failed']);
+
+function getDefaultStorePath(): string {
+  if (process.env.A2A_TASKS_PATH) {
+    return process.env.A2A_TASKS_PATH;
+  }
+
+  const databasePath = process.env.DATABASE_PATH;
+  if (databasePath) {
+    return path.join(path.dirname(databasePath), 'a2a-tasks.json');
+  }
+
+  return path.join(os.homedir(), '.pixcode', 'a2a-tasks.json');
+}
+
+function isTerminalState(state: string): boolean {
+  return TERMINAL_STATES.has(state);
+}
+
+function isTaskShape(value: unknown): value is Task {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const task = value as Partial<Task>;
+  return (
+    typeof task.id === 'string' &&
+    typeof task.state === 'string' &&
+    Array.isArray(task.history) &&
+    Array.isArray(task.artifacts) &&
+    typeof task.createdAt === 'number' &&
+    typeof task.updatedAt === 'number'
+  );
+}
+
+export class A2ATaskStore {
+  private readonly filePath: string;
+  private readonly tmpPath: string;
+  private readonly terminalTaskTtlMs: number;
+  private readonly tasks = new Map<string, Task>();
+
+  constructor(options?: { filePath?: string; terminalTaskTtlMs?: number }) {
+    this.filePath = options?.filePath ?? getDefaultStorePath();
+    this.tmpPath = `${this.filePath}.tmp`;
+    this.terminalTaskTtlMs = options?.terminalTaskTtlMs ?? 60 * 60 * 1000;
+    this.load();
+  }
+
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  entries(): IterableIterator<[string, Task]> {
+    return this.tasks.entries();
+  }
+
+  values(): IterableIterator<Task> {
+    return this.tasks.values();
+  }
+
+  get(taskId: string): Task | undefined {
+    return this.tasks.get(taskId);
+  }
+
+  list(options: {
+    state?: TaskState;
+    contextId?: string;
+    adapterId?: string;
+    limit?: number;
+  } = {}): Task[] {
+    const {
+      state,
+      contextId,
+      adapterId,
+      limit,
+    } = options;
+
+    let tasks = [...this.tasks.values()].sort((a, b) => b.createdAt - a.createdAt);
+
+    if (state) {
+      tasks = tasks.filter((task) => task.state === state);
+    }
+    if (contextId) {
+      tasks = tasks.filter((task) => task.contextId === contextId);
+    }
+    if (adapterId) {
+      tasks = tasks.filter((task) => task.metadata?.adapterId === adapterId);
+    }
+    if (typeof limit === 'number' && Number.isFinite(limit) && limit >= 0) {
+      tasks = tasks.slice(0, limit);
+    }
+
+    return tasks;
+  }
+
+  summarize(task: Task): TaskSummary {
+    return {
+      id: task.id,
+      contextId: task.contextId,
+      state: task.state,
+      adapterId: typeof task.metadata?.adapterId === 'string' ? task.metadata.adapterId : undefined,
+      adapterSelector:
+        typeof task.metadata?.adapterSelector === 'string' ? task.metadata.adapterSelector : undefined,
+      error: task.error,
+      createdAt: task.createdAt,
+      updatedAt: task.updatedAt,
+      messageCount: task.history.length,
+      artifactCount: task.artifacts.length,
+      lastMessage: task.history[task.history.length - 1],
+    };
+  }
+
+  set(task: Task): void {
+    this.tasks.set(task.id, task);
+    this.flush();
+  }
+
+  delete(taskId: string): boolean {
+    const deleted = this.tasks.delete(taskId);
+    if (deleted) {
+      this.flush();
+    }
+    return deleted;
+  }
+
+  private load(): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    if (!fs.existsSync(this.filePath)) {
+      this.flush();
+      return;
+    }
+
+    let parsed: PersistedTaskDocument | null = null;
+    try {
+      parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as PersistedTaskDocument;
+    } catch (error) {
+      const backup = `${this.filePath}.corrupt-${Date.now()}`;
+      console.error(
+        `[A2ATaskStore] Failed to read ${this.filePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }. Backing up to ${backup}.`,
+      );
+      try {
+        fs.renameSync(this.filePath, backup);
+      } catch {
+        // noop
+      }
+      this.flush();
+      return;
+    }
+
+    const now = Date.now();
+    let repaired = false;
+    const tasks = Array.isArray(parsed?.tasks) ? parsed.tasks : [];
+
+    for (const candidate of tasks) {
+      if (!isTaskShape(candidate)) {
+        repaired = true;
+        continue;
+      }
+
+      const task: Task = structuredClone(candidate);
+
+      if (isTerminalState(task.state)) {
+        if (task.updatedAt + this.terminalTaskTtlMs <= now) {
+          repaired = true;
+          continue;
+        }
+      } else {
+        task.state = 'failed';
+        task.error = {
+          code: 'SERVER_RESTARTED',
+          message: 'Pixcode restarted before this A2A task reached a terminal state.',
+        };
+        task.updatedAt = now;
+        repaired = true;
+      }
+
+      this.tasks.set(task.id, task);
+    }
+
+    if (repaired || parsed?.version !== DOCUMENT_VERSION) {
+      this.flush();
+    }
+  }
+
+  private flush(): void {
+    const document: PersistedTaskDocument = {
+      version: DOCUMENT_VERSION,
+      tasks: [...this.tasks.values()].sort((a, b) => a.createdAt - b.createdAt),
+    };
+    fs.writeFileSync(this.tmpPath, JSON.stringify(document, null, 2), 'utf8');
+    fs.renameSync(this.tmpPath, this.filePath);
+  }
+}

--- a/server/modules/orchestration/a2a/types.ts
+++ b/server/modules/orchestration/a2a/types.ts
@@ -76,6 +76,20 @@ export interface Task {
   updatedAt: number;
 }
 
+export interface TaskSummary {
+  id: string;
+  contextId?: string;
+  state: TaskState;
+  adapterId?: string;
+  adapterSelector?: string;
+  error?: TaskError;
+  createdAt: number;
+  updatedAt: number;
+  messageCount: number;
+  artifactCount: number;
+  lastMessage?: Message;
+}
+
 export interface AgentSkill {
   id: string;
   description: string;

--- a/server/modules/orchestration/a2a/validator.ts
+++ b/server/modules/orchestration/a2a/validator.ts
@@ -21,6 +21,19 @@ function assertNonEmptyString(value: unknown, path: string): asserts value is st
   }
 }
 
+function assertOptionalNonEmptyString(value: unknown, path: string): void {
+  if (value === undefined) {
+    return;
+  }
+  assertNonEmptyString(value, path);
+}
+
+function assertPlainObject(value: unknown, path: string): void {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new A2AValidationError('expected plain object', path);
+  }
+}
+
 function assertPart(value: unknown, path: string): asserts value is Part {
   if (!value || typeof value !== 'object') {
     throw new A2AValidationError('expected object', path);
@@ -48,7 +61,7 @@ export function assertMessage(value: unknown, path = '$'): asserts value is Mess
   if (!value || typeof value !== 'object') {
     throw new A2AValidationError('expected object', path);
   }
-  const m = value as { messageId?: unknown; role?: unknown; parts?: unknown };
+  const m = value as { messageId?: unknown; role?: unknown; parts?: unknown; taskId?: unknown };
   assertNonEmptyString(m.messageId, `${path}.messageId`);
   if (m.role !== 'user' && m.role !== 'agent') {
     throw new A2AValidationError('role must be user|agent', `${path}.role`);
@@ -56,6 +69,7 @@ export function assertMessage(value: unknown, path = '$'): asserts value is Mess
   if (!Array.isArray(m.parts) || m.parts.length === 0) {
     throw new A2AValidationError('parts must be non-empty array', `${path}.parts`);
   }
+  assertOptionalNonEmptyString(m.taskId, `${path}.taskId`);
   m.parts.forEach((p, i) => assertPart(p, `${path}.parts[${i}]`));
 }
 
@@ -63,9 +77,18 @@ export function assertSubmitTaskInput(value: unknown): asserts value is SubmitTa
   if (!value || typeof value !== 'object') {
     throw new A2AValidationError('expected object', '$');
   }
-  const v = value as { message?: unknown; adapterId?: unknown };
+  const v = value as {
+    message?: unknown;
+    adapterId?: unknown;
+    contextId?: unknown;
+    metadata?: unknown;
+  };
   assertMessage(v.message, '$.message');
   assertNonEmptyString(v.adapterId, '$.adapterId');
+  assertOptionalNonEmptyString(v.contextId, '$.contextId');
+  if (v.metadata !== undefined) {
+    assertPlainObject(v.metadata, '$.metadata');
+  }
 }
 
 export function assertAgentCard(value: unknown): asserts value is AgentCard {

--- a/server/modules/orchestration/index.ts
+++ b/server/modules/orchestration/index.ts
@@ -6,6 +6,11 @@
 export { createA2ARouter } from './a2a/routes.js';
 export { adapterRegistry } from './a2a/adapter-registry.js';
 export { ClaudeCodeA2AAdapter } from './a2a/adapters/claude-code.adapter.js';
+export { CodexA2AAdapter } from './a2a/adapters/codex.adapter.js';
+export { CursorA2AAdapter } from './a2a/adapters/cursor.adapter.js';
+export { GeminiA2AAdapter } from './a2a/adapters/gemini.adapter.js';
+export { QwenA2AAdapter } from './a2a/adapters/qwen.adapter.js';
+export { OpenCodeA2AAdapter } from './a2a/adapters/opencode.adapter.js';
 export type {
   AdapterContext,
   TaskHandle,
@@ -21,6 +26,7 @@ export type {
   Part,
   SubmitTaskInput,
   Task,
+  TaskSummary,
   TaskError,
   TaskState,
 } from './a2a/types.js';

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -1,0 +1,2 @@
+export { providerRegistry } from './provider.registry.js';
+export { CodexSessionsProvider } from './list/codex/codex-sessions.provider.js';


### PR DESCRIPTION
This PR hardens Pixcode's A2A orchestration foundation while keeping it opt-in.

What changed:
- Added A2A adapters for Codex, Cursor, Gemini, Qwen, and OpenCode.
- Added durable task persistence with restart recovery and terminal-task eviction.
- Added adapter resolution, task listing/filtering, and clearer error responses.
- Expanded the smoke script to cover discovery, resolve, negative paths, listing, and the happy-path roundtrip.
- Updated the changelog and foundation plan to reflect shipped progress.

Impact:
- Existing /api/* and /ws flows continue unchanged.
- External A2A clients now have a usable, queryable orchestration surface.
- The foundation is no longer Claude-only; it is multi-adapter and opt-in by construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new AI adapters (Codex, Cursor, Gemini, Qwen, OpenCode) for expanded orchestration capabilities.
  * Implemented task persistence with automatic restart recovery and TTL-based cleanup.
  * Introduced task listing and filtering API endpoint.
  * Added adapter discovery and resolution API endpoint for routing hints support.

* **Bug Fixes**
  * Improved adapter selector resolution and error messaging.
  * Enhanced task-scoped message history tracking.
  * Strengthened validation for missing/invalid task and adapter references.

* **Tests**
  * Expanded smoke test coverage for adapter registration, negative paths, and task operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->