### PR TITLE
Fix project wizard handoff and add Create New Project CTA

### DIFF
--- a/src/components/main-content/view/subcomponents/MainContentStateView.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentStateView.tsx
@@ -1,4 +1,4 @@
-import { ClipboardCheck, Folder, Sparkles, Workflow } from '@/lib/icons';
+import { ClipboardCheck, Folder, FolderPlus, Sparkles, Workflow } from '@/lib/icons';
 import { useTranslation } from 'react-i18next';
 import type { MainContentStateViewProps } from '../../types/types';
 import MobileMenuButton from './MobileMenuButton';
@@ -52,7 +52,7 @@ export default function MainContentStateView({
               </p>
             </div>
 
-            <div className="grid gap-3 md:grid-cols-3">
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <button
                 type="button"
                 onClick={() => { void onQuickStartOrchestration?.(); }}
@@ -74,6 +74,22 @@ export default function MainContentStateView({
                 <div className="text-sm font-semibold">{t('mainContent.landing.startChat')}</div>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
                   {t('mainContent.landing.startChatDescription')}
+                </p>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent('pixcode:create-project'))}
+                className="rounded-md border border-border p-4 text-left transition-colors hover:bg-muted/40"
+              >
+                <FolderPlus className="mb-3 h-5 w-5 text-foreground" />
+                <div className="text-sm font-semibold">
+                  {t('mainContent.landing.createProject', { defaultValue: 'Create New Project' })}
+                </div>
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  {t('mainContent.landing.createProjectDescription', {
+                    defaultValue: 'Add an existing workspace or create a folder, then open the provider picker for coding.',
+                  })}
                 </p>
               </button>
 

--- a/src/components/project-creation-wizard/ProjectCreationWizard.tsx
+++ b/src/components/project-creation-wizard/ProjectCreationWizard.tsx
@@ -10,11 +10,12 @@ import WizardProgress from './components/WizardProgress';
 import { useGithubTokens } from './hooks/useGithubTokens';
 import { cloneWorkspaceWithProgress, createWorkspaceRequest } from './data/workspaceApi';
 import { isCloneWorkflow, shouldShowGithubAuthentication } from './utils/pathUtils';
+import type { Project } from '../../types/app';
 import type { TokenMode, WizardFormState, WizardStep, WorkspaceType } from './types';
 
 type ProjectCreationWizardProps = {
   onClose: () => void;
-  onProjectCreated?: (project?: Record<string, unknown>) => void;
+  onProjectCreated?: (project?: Project) => void;
 };
 
 const initialFormState: WizardFormState = {

--- a/src/components/project-creation-wizard/data/workspaceApi.ts
+++ b/src/components/project-creation-wizard/data/workspaceApi.ts
@@ -109,7 +109,7 @@ export const cloneWorkspaceWithProgress = (
   params: CloneWorkspaceParams,
   handlers: CloneProgressHandlers,
 ) =>
-  new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
+  new Promise<CreateWorkspaceResponse['project']>((resolve, reject) => {
     const query = buildCloneProgressQuery(params);
     const eventSource = new EventSource(`/api/projects/clone-progress?${query}`);
     let settled = false;

--- a/src/components/project-creation-wizard/types.ts
+++ b/src/components/project-creation-wizard/types.ts
@@ -1,3 +1,5 @@
+import type { Project } from '../../types/app';
+
 export type WizardStep = 1 | 2 | 3;
 
 // 'existing'  — open the picked folder as-is
@@ -47,7 +49,7 @@ export type CreateWorkspacePayload = {
 
 export type CreateWorkspaceResponse = {
   success?: boolean;
-  project?: Record<string, unknown>;
+  project?: Project;
   alreadyExisted?: boolean;
   error?: string;
   details?: string;
@@ -57,7 +59,7 @@ export type CreateWorkspaceResponse = {
 export type CloneProgressEvent = {
   type?: string;
   message?: string;
-  project?: Record<string, unknown>;
+  project?: Project;
 };
 
 export type WizardFormState = {

--- a/src/components/sidebar/types/types.ts
+++ b/src/components/sidebar/types/types.ts
@@ -28,6 +28,7 @@ export type SidebarProps = {
   onProjectSelect: (project: Project) => void;
   onSessionSelect: (session: ProjectSession) => void;
   onNewSession: (project: Project) => void;
+  onProjectCreated?: (project: Project) => void;
   onOpenOrchestration?: (project: Project, runId?: string) => void;
   /** Zero-config new-chat action: auto-creates a pixcode-project-N on the
    *  server and lands the user on the chat screen. Plumbed through to

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -28,6 +28,7 @@ function Sidebar({
   onProjectSelect,
   onSessionSelect,
   onNewSession,
+  onProjectCreated,
   onOpenOrchestration,
   onQuickStartSession,
   onSessionDelete,
@@ -122,6 +123,16 @@ function Sidebar({
   });
 
   useEffect(() => {
+    const handleCreateProjectRequest = () => setShowNewProject(true);
+
+    window.addEventListener('pixcode:create-project', handleCreateProjectRequest);
+
+    return () => {
+      window.removeEventListener('pixcode:create-project', handleCreateProjectRequest);
+    };
+  }, [setShowNewProject]);
+
+  useEffect(() => {
     if (typeof document === 'undefined') {
       return;
     }
@@ -130,13 +141,19 @@ function Sidebar({
     document.body.classList.toggle('pwa-mode', isPWA);
   }, [isPWA]);
 
-  const handleProjectCreated = () => {
+  const handleProjectCreated = (project?: Project) => {
+    if (project) {
+      onProjectCreated?.(project);
+    }
+
     if (window.refreshProjects) {
       void window.refreshProjects();
       return;
     }
 
-    window.location.reload();
+    if (!project) {
+      window.location.reload();
+    }
   };
 
   // Shared editing-session callbacks so the grouped and flat list use identical behavior.

--- a/src/components/sidebar/view/subcomponents/SidebarModals.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarModals.tsx
@@ -19,7 +19,7 @@ type SidebarModalsProps = {
   onCloseSettings: () => void;
   showNewProject: boolean;
   onCloseNewProject: () => void;
-  onProjectCreated: () => void;
+  onProjectCreated: (project?: Project) => void;
   deleteConfirmation: DeleteProjectConfirmation | null;
   onCancelDeleteProject: () => void;
   onConfirmDeleteProject: (deleteData?: boolean) => void;

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -477,8 +477,24 @@ export function useProjectsState({
     [activeTab, isMobile, navigate, selectedProject?.name],
   );
 
-  const handleNewSession = useCallback(
+  const openProjectChat = useCallback(
     (project: Project) => {
+      setProjects((prevProjects) => {
+        const existingIndex = prevProjects.findIndex(
+          (existingProject) => existingProject.name === project.name,
+        );
+
+        if (existingIndex === -1) {
+          return [project, ...prevProjects];
+        }
+
+        const nextProjects = [...prevProjects];
+        nextProjects[existingIndex] = {
+          ...nextProjects[existingIndex],
+          ...project,
+        };
+        return nextProjects;
+      });
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab('chat');
@@ -489,6 +505,13 @@ export function useProjectsState({
       }
     },
     [isMobile, navigate],
+  );
+
+  const handleNewSession = useCallback(
+    (project: Project) => {
+      openProjectChat(project);
+    },
+    [openProjectChat],
   );
 
   /**
@@ -510,6 +533,11 @@ export function useProjectsState({
         return;
       }
       const project = body.project as Project;
+      if (targetTab === 'chat') {
+        openProjectChat(project);
+        return;
+      }
+
       setProjects((prev) => (
         prev.some((p) => p.name === project.name) ? prev : [project, ...prev]
       ));
@@ -521,7 +549,7 @@ export function useProjectsState({
     } catch (err) {
       console.error('[quick-start] error:', err);
     }
-  }, [isMobile, navigate]);
+  }, [isMobile, navigate, openProjectChat]);
 
   const handleQuickStartSession = useCallback(async () => {
     await quickStartIntoTab('chat');
@@ -635,6 +663,7 @@ export function useProjectsState({
       onProjectSelect: handleProjectSelect,
       onSessionSelect: handleSessionSelect,
       onNewSession: handleNewSession,
+      onProjectCreated: openProjectChat,
       onQuickStartSession: handleQuickStartSession,
       onOpenOrchestration: handleOpenOrchestration,
       onSessionDelete: handleSessionDelete,
@@ -651,6 +680,7 @@ export function useProjectsState({
     [
       handleNewSession,
       handleOpenOrchestration,
+      openProjectChat,
       handleQuickStartSession,
       handleProjectDelete,
       handleProjectSelect,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -104,7 +104,9 @@
       "startChatDescription": "Creates a folder automatically and opens the normal chat screen with one agent.",
       "taskSystem": "Task system",
       "taskSystemDescription": "Use the TaskMaster tab inside a project to track work items, status, and planned work.",
-      "sidebarHint": "When you select an existing project from the sidebar, chat history, files, git status, tasks, and orchestration stay in the same main screen."
+      "sidebarHint": "When you select an existing project from the sidebar, chat history, files, git status, tasks, and orchestration stay in the same main screen.",
+      "createProject": "Create New Project",
+      "createProjectDescription": "Add an existing workspace or create a folder, then open the provider picker for coding."
     }
   },
   "orchestration": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -104,7 +104,9 @@
       "startChatDescription": "Klasör otomatik oluşturulur ve normal chat ekranında tek ajanla ilerlersin.",
       "taskSystem": "Task sistemi",
       "taskSystemDescription": "Proje içinde iş listesini, durumları ve planlı işleri takip etmek için TaskMaster sekmesini kullanırsın.",
-      "sidebarHint": "Kenar çubuğundan mevcut bir proje seçersen sohbet geçmişi, dosyalar, git durumu, task sistemi ve orkestrasyon aynı ana ekranda kalır."
+      "sidebarHint": "Kenar çubuğundan mevcut bir proje seçersen sohbet geçmişi, dosyalar, git durumu, task sistemi ve orkestrasyon aynı ana ekranda kalır.",
+      "createProject": "Yeni Proje Oluştur",
+      "createProjectDescription": "Mevcut çalışma alanını ekle veya klasör oluştur; ardından kodlamaya başlamak için CLI seçim ekranına geç."
     }
   },
   "orchestration": {


### PR DESCRIPTION
### Motivation
- The project-creation wizard could add a workspace but not reliably open/select it in the app, leaving users waiting for a CLI/provider picker that never appeared. 
- The empty "New chat" / landing screen had no direct entry to the project wizard, which increases friction for starting a project. 
- The wizard callback and API types were loosely typed so the created project could not be passed cleanly into app state. 

### Description
- Wire the wizard `onProjectCreated` callback through `SidebarModals` and `Sidebar` so the sidebar can refresh and (when available) hand the newly-created project into app state. 
- Add `openProjectChat` logic in `useProjectsState` to merge the created project into the projects list, select it, switch to the `chat` tab, and navigate to `/` so the CLI/provider picker appears. 
- Make workspace creation responses strongly typed as `Project` in the wizard client code (`types.ts`, `workspaceApi.ts`, `ProjectCreationWizard.tsx`) and in the clone-progress SSE handling so the callback receives a usable `Project` object. 
- Add a "Create New Project" CTA to the empty landing (New Chat) screen that fires `window.dispatchEvent(new CustomEvent('pixcode:create-project'))` and a corresponding `window` listener in `Sidebar` to open the wizard. 
- Add English and Turkish translation keys for the new landing CTA. 

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npm run lint -- --quiet` and there were no lint errors (only existing warnings). 
- Built the client with `npm run build:client` which completed successfully (build emitted CSS minifier warnings and chunk-size warnings but produced `dist/`). 
- Verified `git diff --check` / whitespace checks showed no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc583c4bd8832d81e924c3e4706a29)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Create New Project" card to the landing page for streamlined project creation access.
  * Enhanced project creation workflow with improved event handling.

* **Localization**
  * Added translation strings for the new project creation interface (English and Turkish).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->