### PR TITLE
fix: the websocket upgrade handler in server/ws in ws.js

### DIFF
--- a/server/ws.js
+++ b/server/ws.js
@@ -13,6 +13,12 @@ export function createHub(server) {
     return token ? verifyToken(token) : null
   }
 
+  function isAllowedOrigin(origin) {
+    if (!origin) return true
+    if (origin === 'tauri://localhost' || origin === 'http://tauri.localhost' || origin === 'https://tauri.localhost') return true
+    return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)
+  }
+
   function broadcast(channel, event, data) {
     const frame = JSON.stringify({ ch: channel, ev: event, data })
     for (const connection of connections) {
@@ -24,6 +30,7 @@ export function createHub(server) {
     let url
     try { url = new URL(req.url, 'http://localhost') } catch { socket.destroy(); return }
     if (url.pathname !== '/ws') { socket.destroy(); return }
+    if (!isAllowedOrigin(req.headers.origin)) { socket.destroy(); return }
     const principal = authenticate(url)
     if (!principal) {
       socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n')


### PR DESCRIPTION
## Summary
Fix high severity security issue in `server/ws.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `server/ws.js:1` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 3-step |

**Description**: The WebSocket upgrade handler in server/ws.js does not validate the Origin header. Without origin validation, a malicious website can open a cross-origin WebSocket connection to the pixcode server. If a victim visits the attacker's site while authenticated, the browser sends credentials automatically, allowing the attacker to send crafted messages to channels like 'pty' or 'fs'.

## Evidence

**Exploitation scenario**: An attacker who controls a malicious website and has a victim authenticated to pixcode can open a WebSocket connection from the malicious site.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js command-line tool - exploitation requires the attacker to control the arguments, input files or environment the tool is run with.

## Changes
- `server/ws.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now accept supported desktop app and local development origins.
  * Connections from unrecognized origins are rejected before authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->